### PR TITLE
Pass context to asyncData to provide origin for vuex actions

### DIFF
--- a/ClientApp/components/Messages.vue
+++ b/ClientApp/components/Messages.vue
@@ -12,10 +12,10 @@ import Message from './Message.vue';
 export default {
   components: { Message },
   computed: mapGetters(['messages', 'lastFetchedMessageDate']),
-  methods: 
-    mapActions(['fetchMessages']), 
-    asyncData ({ store }) {
-      return store.dispatch('fetchInitialMessages')
+  methods:
+    mapActions(['fetchMessages']),
+    asyncData ({ store, context }) {
+      return store.dispatch('fetchInitialMessages', context.origin)
     }
 }
 </script>

--- a/ClientApp/server.js
+++ b/ClientApp/server.js
@@ -11,7 +11,7 @@ export default context => {
       }
       Promise.all(matchedComponents.map(Component => {
         if (Component.asyncData) {
-          return Component.asyncData({ store })
+          return Component.asyncData({ store, context })
         }
       }))
       .then(() => {

--- a/ClientApp/vuex/actions.js
+++ b/ClientApp/vuex/actions.js
@@ -1,8 +1,8 @@
 import axios from 'axios'
 
-export const fetchInitialMessages = ({commit}) => {
+export const fetchInitialMessages = ({commit}, origin) => {
   // this one will run on server so it need FQDN or server won't able to resolve the API address
-  return axios.get('http://localhost:5000/initialMessages').then(response => {
+  return axios.get(`${origin}/initialMessages`).then(response => {
     commit('INITIAL_MESSAGES', response.data)
   }).catch(err => {
     console.log(err)
@@ -10,7 +10,7 @@ export const fetchInitialMessages = ({commit}) => {
 }
 
 export const fetchMessages = ({commit}, lastFetchedMessageDate) => {
-  axios.post('http://localhost:5000/fetchMessages',{
+  axios.post('/fetchMessages',{
     lastMessageDate : lastFetchedMessageDate
   })
     .then(response => {


### PR DESCRIPTION
Replace FQDNs in `actions.js` by passing origin via `asyncData` for server-side requests.