### PR TITLE
Get origin from window.location for client-side calls in asyncData

### DIFF
--- a/ClientApp/components/Messages.vue
+++ b/ClientApp/components/Messages.vue
@@ -15,7 +15,8 @@ export default {
   methods:
     mapActions(['fetchMessages']),
     asyncData ({ store, context }) {
-      return store.dispatch('fetchInitialMessages', context.origin)
+      let origin = context ? context.origin : window.location.origin
+      return store.dispatch('fetchInitialMessages', origin)
     }
 }
 </script>


### PR DESCRIPTION
I realised my previous change broke for client-side calls to `asyncData`. This should cover both cases.